### PR TITLE
fix: 🐛 parse standalone flag correctly

### DIFF
--- a/src/parser/directive/directive.parser.spec.ts
+++ b/src/parser/directive/directive.parser.spec.ts
@@ -53,4 +53,49 @@ describe('DirectiveParser', () => {
 
     expect(parseDirective(ast, filePath)).toEqual(expectedOutput);
   });
+
+  it('should extract all the properties from the standalone directive', function () {
+    const filePath = 'foo.directive.ts';
+    const implementation = `export class MyTestDirective {
+                @Input() foo: string;
+                @Output() bar = new EventEmitter();
+            }`;
+
+    const ast = tsquery.ast(`
+            @Directive({
+                selector: '[myTestDirective]',
+                standalone: true
+            })
+            ${implementation}
+        `);
+    const expectedOutput = {
+      type: NgParselOutputType.DIRECTIVE,
+      className: 'MyTestDirective',
+      filePath,
+      selector: '[myTestDirective]',
+      standalone: true,
+      inputs: [
+        {
+          decorator: '@Input()',
+          name: 'foo',
+          type: 'string',
+          initializer: undefined,
+          field: '@Input() foo: string',
+        },
+      ],
+      outputs: [
+        {
+          decorator: '@Output()',
+          name: 'bar',
+          type: undefined,
+          initializer: 'new EventEmitter()',
+          field: '@Output() bar = new EventEmitter()',
+        },
+      ],
+      implementation,
+    };
+    jest.spyOn(fs, 'readFileSync').mockReturnValue(implementation);
+
+    expect(parseDirective(ast, filePath)).toEqual(expectedOutput);
+  });
 });

--- a/src/parser/pipe/pipe.parser.spec.ts
+++ b/src/parser/pipe/pipe.parser.spec.ts
@@ -40,4 +40,36 @@ describe('PipeParser', () => {
 
     expect(parsePipe(ast, filePath)).toEqual(expectedPipe);
   });
+
+  it('should parse standalone Angular pipes to NgParselPipes', () => {
+    const filePath = 'my-test.pipe.ts';
+    const implementation = `export class MyPipe implements PipeTransform {
+            
+                transform(value: any, ...args: any[]): any {
+                   return null;
+                }
+            }`;
+
+    const ast = tsquery.ast(`
+            @Pipe({
+                name: 'myPipe',
+                standalone: true
+            })
+            ${implementation}
+        `);
+
+    const expectedPipe = {
+      type: NgParselOutputType.PIPE,
+      filePath,
+      className: 'MyPipe',
+      name: 'myPipe',
+      pure: true,
+      standalone: true,
+      implementation,
+    };
+
+    jest.spyOn(fs, 'readFileSync').mockReturnValue(implementation);
+
+    expect(parsePipe(ast, filePath)).toEqual(expectedPipe);
+  });
 });

--- a/src/parser/shared/parser/decorator.parser.spec.ts
+++ b/src/parser/shared/parser/decorator.parser.spec.ts
@@ -3,7 +3,7 @@ import { tsquery } from '@phenomnomnominal/tsquery';
 import { getDecoratorProperties } from './decorator.parser.js';
 
 describe('DecoratorParser', () => {
-  it('should parse decorator properties', () => {
+  it('should parse component decorator properties', () => {
     const ast = tsquery.ast(`
             @Component({
                 selector: 'my-component',
@@ -15,6 +15,89 @@ describe('DecoratorParser', () => {
     const expectedDecorators = {
       selector: 'my-component',
       template: '<div></div>',
+    };
+
+    expect(getDecoratorProperties(ast)).toEqual(expectedDecorators);
+  });
+
+  it('should parse standalone component decorator properties', () => {
+    const ast = tsquery.ast(`
+            @Component({
+                selector: 'my-component',
+                template: '<div></div>',
+                standalone: true,
+            })
+            export class MyTestClass {}
+        `);
+
+    const expectedDecorators = {
+      selector: 'my-component',
+      template: '<div></div>',
+      standalone: true,
+    };
+
+    expect(getDecoratorProperties(ast)).toEqual(expectedDecorators);
+  });
+
+  it('should parse directive decorator properties', () => {
+    const ast = tsquery.ast(`
+            @Component({
+                selector: 'my-directive',
+            })
+            export class MyTestClass {}
+        `);
+
+    const expectedDecorators = {
+      selector: 'my-directive',
+    };
+
+    expect(getDecoratorProperties(ast)).toEqual(expectedDecorators);
+  });
+
+  it('should parse standalone directive decorator properties', () => {
+    const ast = tsquery.ast(`
+            @Component({
+                selector: 'my-directive',
+                standalone: true,
+            })
+            export class MyTestClass {}
+        `);
+
+    const expectedDecorators = {
+      selector: 'my-directive',
+      standalone: true,
+    };
+
+    expect(getDecoratorProperties(ast)).toEqual(expectedDecorators);
+  });
+
+  it('should parse pipe decorator properties', () => {
+    const ast = tsquery.ast(`
+            @Component({
+                name: 'my-pipe',
+            })
+            export class MyTestClass {}
+        `);
+
+    const expectedDecorators = {
+      name: 'my-pipe',
+    };
+
+    expect(getDecoratorProperties(ast)).toEqual(expectedDecorators);
+  });
+
+  it('should parse pipe decorator properties', () => {
+    const ast = tsquery.ast(`
+            @Component({
+                name: 'my-pipe',
+                standalone: true,
+            })
+            export class MyTestClass {}
+        `);
+
+    const expectedDecorators = {
+      name: 'my-pipe',
+      standalone: true,
     };
 
     expect(getDecoratorProperties(ast)).toEqual(expectedDecorators);

--- a/src/parser/shared/parser/decorator.parser.spec.ts
+++ b/src/parser/shared/parser/decorator.parser.spec.ts
@@ -41,7 +41,7 @@ describe('DecoratorParser', () => {
 
   it('should parse directive decorator properties', () => {
     const ast = tsquery.ast(`
-            @Component({
+            @Directive({
                 selector: 'my-directive',
             })
             export class MyTestClass {}
@@ -56,7 +56,7 @@ describe('DecoratorParser', () => {
 
   it('should parse standalone directive decorator properties', () => {
     const ast = tsquery.ast(`
-            @Component({
+            @Directive({
                 selector: 'my-directive',
                 standalone: true,
             })
@@ -73,7 +73,7 @@ describe('DecoratorParser', () => {
 
   it('should parse pipe decorator properties', () => {
     const ast = tsquery.ast(`
-            @Component({
+            @Pipe({
                 name: 'my-pipe',
             })
             export class MyTestClass {}
@@ -88,7 +88,7 @@ describe('DecoratorParser', () => {
 
   it('should parse pipe decorator properties', () => {
     const ast = tsquery.ast(`
-            @Component({
+            @Pipe({
                 name: 'my-pipe',
                 standalone: true,
             })

--- a/src/parser/shared/parser/decorator.parser.ts
+++ b/src/parser/shared/parser/decorator.parser.ts
@@ -3,11 +3,26 @@ import { tsquery } from '@phenomnomnominal/tsquery';
 
 import { NgParselDecoratorProperties } from '../model/decorator.model.js';
 
+const booleanDecoratorProps = ['standalone', 'pure'];
+
 export function getDecoratorProperties(ast: ts.SourceFile): NgParselDecoratorProperties {
-  const componentDecorators = tsquery(ast, 'Decorator > CallExpression > ObjectLiteralExpression > PropertyAssignment');
+  const decoratorQuery = 'Decorator > CallExpression > ObjectLiteralExpression > PropertyAssignment';
+  const componentDecorators = tsquery(ast, decoratorQuery);
 
   return componentDecorators.reduce((decorators: any, propertyAssignment: any) => {
     const propertyName = propertyAssignment.name.escapedText;
+
+    if (propertyName === 'styleUrls' || propertyName === 'styles') {
+      const styleTokens = tsquery(ast, `${decoratorQuery} > ArrayLiteralExpression > StringLiteral`);
+      decorators[propertyName] = styleTokens.map((token) => token.getText().replace(/'/g, ''));
+      return decorators;
+    }
+
+    if (booleanDecoratorProps.includes(propertyName)) {
+      decorators[propertyName] = propertyAssignment.initializer.getText() === 'true';
+      return decorators;
+    }
+
     decorators[propertyName] = propertyAssignment.initializer.text;
     return decorators;
   }, {});


### PR DESCRIPTION
Parse the standalone flag of declarables (components, pipes, and directives) properly, so we get exact information on output

✅ Closes: #24